### PR TITLE
docs:yml 파일 분리

### DIFF
--- a/src/main/resources/application-auth.yml
+++ b/src/main/resources/application-auth.yml
@@ -1,0 +1,7 @@
+jwt:
+  secret: 'aDj9oGoq3wDevudOXmxj4e124sdghsaor1q3asdfllk11kmnmr'
+
+app:
+  auth:
+    accessTokenExpiry: 1800000
+    refreshTokenExpiry: 1209600000

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -1,0 +1,24 @@
+spring:
+  h2:
+    console:
+      enabled: true
+      path: /h2-console
+
+  datasource:
+    hikari:
+      jdbc-url: jdbc:h2:tcp://localhost/~/sendwish
+    driver-class-name: org.h2.Driver
+    username: sa
+    password:
+
+  jpa:
+    database-platform: org.hibernate.dialect.H2Dialect
+    properties:
+      hibernate:
+        format_sql: true
+        show_sql: true
+        dialect: org.hibernate.dialect.H2Dialect
+    hibernate:
+      ddl-auto: create-drop
+
+

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,36 +1,21 @@
-spring:
-  h2:
-    console:
-      enabled: true
-      path: /h2-console
-
-  datasource:
-    hikari:
-      jdbc-url: jdbc:h2:tcp://localhost/~/sendwish
-    driver-class-name: org.h2.Driver
-    username: sa
-    password:
-
-  jpa:
-    database-platform: org.hibernate.dialect.H2Dialect
-    properties:
-      hibernate:
-        format_sql: true
-        show_sql: true
-        dialect: org.hibernate.dialect.H2Dialect
-    hibernate:
-      ddl-auto: create-drop
-
-
 server:
   port: 8080
   tomcat:
     uri-encoding: UTF-8
 
-jwt:
-  secret: 'aDj9oGoq3wDevudOXmxj4e124sdghsaor1q3asdfllk11kmnmr'
+spring:
+  profiles:
+    active: local
+    include:
+      - aws
+      - email
+      - auth
 
-app:
-  auth:
-    accessTokenExpiry: 1800000
-    refreshTokenExpiry: 1209600000
+logging:
+  level:
+    com.zaxxer.hikari.HikariConfig: DEBUG
+    com.zaxxer.hikari: TRACE
+
+
+
+


### PR DESCRIPTION
### 작업 개요
- yml 파일 분리
- EC2 서버에서의 환경과 로컬 컴퓨터에서 환경 설정 값들이 다르기 때문에 서로 분리해서 적용합니다.
- 구체적인 예로 로컬에서는 테스트로 H2 DB 사용하고, EC2 배포에서 Mysql을 쓰면 이들의 jdbc 경로를 잡아야합니다.
- `application.yml`의 active 프로퍼티를 변경하면서 작업해주면됩니다.
- 로컬에서 할 경우 `local`, 서버에 배포할 경우 `dev`로 설정합시다!

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [x]  문서화