### PR TITLE
feat:MYSQL 연결 설정

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -23,14 +23,18 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 	implementation 'org.springframework.boot:spring-boot-starter-web'
 	compileOnly 'org.projectlombok:lombok'
-	runtimeOnly 'com.h2database:h2'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+
 	//jwt
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.5'
 	implementation 'io.jsonwebtoken:jjwt-jackson:0.11.5'
+
+	//DB
+	runtimeOnly 'mysql:mysql-connector-java'
+	runtimeOnly 'com.h2database:h2'
 }
 
 tasks.named('test') {

--- a/build.sh
+++ b/build.sh
@@ -1,0 +1,18 @@
+#! /bin/bash
+echo "==================================================="
+echo "Gradle 빌드를 실행합니다"
+echo "==================================================="
+./gradlew build -x test
+echo "done."
+
+echo "==================================================="
+echo "Dockerfile을 build합니다."
+echo "==================================================="
+ docker build --build-arg DEPENDENCY=build/dependency -t hcs4125/sendwish_back --platform linux/amd64 .
+echo "done."
+
+echo "==================================================="
+echo "Dockerfile을 push합니다." 
+echo "==================================================="
+docker push hcs4125/sendwish_back 
+echo "done."


### PR DESCRIPTION
### 작업 개요
- AWS RDS의 MySql 서버를 스프링부트 서버와 연결
- 현재 작업자 본인의 IPV4주소만 RDS의 인바운드 포트에 허용되어있음
- 추후,팀원들의 IPV4 연결 필요
- build.gradle에 mysql 의존성 추가
- 깃 이그노어 파일인 application-dev.yml의 설정사항 변경
- 신속한 도커 파일 빌드를 위한 쉘 스크립트 추가

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화