### PR TITLE
feat:Collection 엔티티,사용자 별 Collection Read 기능

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM openjdk:11-jdk-slim
+FROM openjdk:16-jdk-slim
 EXPOSE 8081
 ARG JAR_FILE=./build/libs/backend-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar

--- a/build.gradle
+++ b/build.gradle
@@ -6,7 +6,7 @@ plugins {
 
 group = 'link.sendwish'
 version = '0.0.1-SNAPSHOT'
-sourceCompatibility = '11'
+sourceCompatibility = "16"
 
 configurations {
 	compileOnly {
@@ -40,3 +40,4 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+targetCompatibility = JavaVersion.VERSION_16

--- a/src/main/java/link/sendwish/backend/controller/CollectionController.java
+++ b/src/main/java/link/sendwish/backend/controller/CollectionController.java
@@ -1,0 +1,40 @@
+package link.sendwish.backend.controller;
+
+import link.sendwish.backend.dtos.CollectionResponseDto;
+import link.sendwish.backend.dtos.ResponseErrorDto;
+import link.sendwish.backend.entity.Member;
+import link.sendwish.backend.service.CollectionService;
+import link.sendwish.backend.service.MemberService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+public class CollectionController {
+
+    private final MemberService memberService;
+
+    @GetMapping("/collections/{memberId}")
+    public ResponseEntity<?> getCollections(@PathVariable("memberId") String memberId) {
+        try {
+            Member member = memberService.findMember(memberId);
+            List<CollectionResponseDto> memberCollection = memberService.findMemberCollection(member);
+            return ResponseEntity.ok().body(memberCollection);
+        }catch (Exception e) {
+            e.printStackTrace();
+            ResponseErrorDto errorDto = ResponseErrorDto.builder()
+                    .error(e.getMessage())
+                    .build();
+            return ResponseEntity.internalServerError().body(errorDto);
+        }
+    }
+
+
+}

--- a/src/main/java/link/sendwish/backend/dtos/CollectionResponseDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/CollectionResponseDto.java
@@ -1,0 +1,16 @@
+package link.sendwish.backend.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CollectionResponseDto {
+    private String title;
+    private String memberId;
+    //추후 item 관련 field 추가
+}

--- a/src/main/java/link/sendwish/backend/entity/BaseTime.java
+++ b/src/main/java/link/sendwish/backend/entity/BaseTime.java
@@ -1,0 +1,23 @@
+package link.sendwish.backend.entity;
+
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedBy;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import java.time.LocalDateTime;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTime {
+    @CreatedDate
+    @Column(updatable = false)
+    private LocalDateTime createAt;
+
+    @LastModifiedBy
+    private LocalDateTime lastModifiedAt;
+}

--- a/src/main/java/link/sendwish/backend/entity/Collection.java
+++ b/src/main/java/link/sendwish/backend/entity/Collection.java
@@ -1,0 +1,23 @@
+package link.sendwish.backend.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Collection extends BaseTime{
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @OneToMany(mappedBy = "collection")
+    private List<MemberCollection> memberCollections = new ArrayList<>();
+
+    private String title;
+}

--- a/src/main/java/link/sendwish/backend/entity/Member.java
+++ b/src/main/java/link/sendwish/backend/entity/Member.java
@@ -1,9 +1,6 @@
 package link.sendwish.backend.entity;
 
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
 import org.springframework.security.core.userdetails.UserDetails;
@@ -16,7 +13,7 @@ import java.util.stream.Collectors;
 
 @Getter
 @Builder
-@NoArgsConstructor
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
 @AllArgsConstructor
 @Entity
 public class Member implements UserDetails {
@@ -35,6 +32,9 @@ public class Member implements UserDetails {
     @ElementCollection(fetch = FetchType.EAGER)
     @Builder.Default
     private List<String> roles = new ArrayList<>();
+
+    @OneToMany(mappedBy = "member")
+    private List<MemberCollection> memberCollections = new ArrayList<>();
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/link/sendwish/backend/entity/MemberCollection.java
+++ b/src/main/java/link/sendwish/backend/entity/MemberCollection.java
@@ -1,0 +1,20 @@
+package link.sendwish.backend.entity;
+
+
+import javax.persistence.*;
+
+@Entity
+public class MemberCollection {
+    @Id
+    @GeneratedValue
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "member_id")
+    private Member member;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "collection_id")
+    private Collection collection;
+
+}

--- a/src/main/java/link/sendwish/backend/entity/MemberCollection.java
+++ b/src/main/java/link/sendwish/backend/entity/MemberCollection.java
@@ -1,8 +1,11 @@
 package link.sendwish.backend.entity;
 
 
+import lombok.Getter;
+
 import javax.persistence.*;
 
+@Getter
 @Entity
 public class MemberCollection {
     @Id

--- a/src/main/java/link/sendwish/backend/repository/CollectionRepository.java
+++ b/src/main/java/link/sendwish/backend/repository/CollectionRepository.java
@@ -1,0 +1,10 @@
+package link.sendwish.backend.repository;
+
+import link.sendwish.backend.entity.Collection;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface CollectionRepository extends JpaRepository<Collection,Long> {
+
+}

--- a/src/main/java/link/sendwish/backend/repository/MemberCollectionRepository.java
+++ b/src/main/java/link/sendwish/backend/repository/MemberCollectionRepository.java
@@ -1,0 +1,12 @@
+package link.sendwish.backend.repository;
+
+import link.sendwish.backend.entity.Member;
+import link.sendwish.backend.entity.MemberCollection;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+import java.util.Optional;
+
+public interface MemberCollectionRepository extends JpaRepository<MemberCollection, Long> {
+    Optional<List<MemberCollection>> findAllByMember(Member member);
+}

--- a/src/main/java/link/sendwish/backend/service/CollectionService.java
+++ b/src/main/java/link/sendwish/backend/service/CollectionService.java
@@ -1,0 +1,22 @@
+package link.sendwish.backend.service;
+
+import link.sendwish.backend.repository.CollectionRepository;
+import link.sendwish.backend.repository.MemberCollectionRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+@Slf4j
+public class CollectionService {
+
+    private final CollectionRepository collectionRepository;
+    private final MemberCollectionRepository memberCollectionRepository;
+
+
+
+
+}

--- a/src/main/java/link/sendwish/backend/service/MemberService.java
+++ b/src/main/java/link/sendwish/backend/service/MemberService.java
@@ -2,8 +2,12 @@ package link.sendwish.backend.service;
 
 import link.sendwish.backend.auth.JwtTokenProvider;
 import link.sendwish.backend.auth.TokenInfo;
+import link.sendwish.backend.dtos.CollectionResponseDto;
 import link.sendwish.backend.dtos.MemberRequestDto;
+import link.sendwish.backend.entity.Collection;
 import link.sendwish.backend.entity.Member;
+import link.sendwish.backend.entity.MemberCollection;
+import link.sendwish.backend.repository.MemberCollectionRepository;
 import link.sendwish.backend.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -14,8 +18,10 @@ import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Stream;
 
 @Service
 @Transactional(readOnly = true)
@@ -26,6 +32,7 @@ public class MemberService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
+    private final MemberCollectionRepository memberCollectionRepository;
 
     @Transactional
     public Member createMember(MemberRequestDto dto) {
@@ -49,5 +56,22 @@ public class MemberService {
             return jwtTokenProvider.generateToken(authentication);
         }
         throw new RuntimeException("비밀번호가 일치하지 않습니다.");
+    }
+
+    public Member findMember(String memberId) {
+        return memberRepository.findByMemberId(memberId).orElseThrow(RuntimeException::new);
+    }
+
+    public List<CollectionResponseDto> findMemberCollection(Member member) {
+        return memberCollectionRepository
+                .findAllByMember(member)
+                .orElseThrow(RuntimeException::new)
+                .stream()
+                .map(target -> CollectionResponseDto
+                        .builder()
+                        .title(target.getCollection().getTitle())
+                        .memberId(target.getMember().getUsername())
+                        .build()
+                ).toList();
     }
 }


### PR DESCRIPTION
### 작업 개요
- Collection 엔티티 추가
- CollectionController에서 memberId(사용자가 설정한 Id)로 사용자의 Collection정보 받아오는 API 구현
- 전달되는 Collectioin 정보 : title,memberId,(추후 item image)
- stream().map().toList() 사용을 위해 JDK 16버전으로 변경(findMemberCollection 메서드)

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화