### PR TITLE
feat:컬렉션 등록 api 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:16-jdk-slim
 EXPOSE 8081
 ARG JAR_FILE=./build/libs/backend-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","/app.jar"]
+ENTRYPOINT ["java","-jar","-Dspring.profiels,active=dev","/app.jar"]

--- a/src/main/java/link/sendwish/backend/BackendApplication.java
+++ b/src/main/java/link/sendwish/backend/BackendApplication.java
@@ -2,7 +2,9 @@ package link.sendwish.backend;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
 
+@EnableJpaAuditing
 @SpringBootApplication
 public class BackendApplication {
 

--- a/src/main/java/link/sendwish/backend/controller/CollectionController.java
+++ b/src/main/java/link/sendwish/backend/controller/CollectionController.java
@@ -1,5 +1,6 @@
 package link.sendwish.backend.controller;
 
+import link.sendwish.backend.dtos.CollectionRequestDto;
 import link.sendwish.backend.dtos.CollectionResponseDto;
 import link.sendwish.backend.dtos.ResponseErrorDto;
 import link.sendwish.backend.entity.Member;
@@ -8,9 +9,7 @@ import link.sendwish.backend.service.MemberService;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 
@@ -20,13 +19,29 @@ import java.util.List;
 public class CollectionController {
 
     private final MemberService memberService;
+    private final CollectionService collectionService;
 
     @GetMapping("/collections/{memberId}")
-    public ResponseEntity<?> getCollections(@PathVariable("memberId") String memberId) {
+    public ResponseEntity<?> getCollectionsByMember(@PathVariable("memberId") String memberId) {
         try {
             Member member = memberService.findMember(memberId);
             List<CollectionResponseDto> memberCollection = memberService.findMemberCollection(member);
             return ResponseEntity.ok().body(memberCollection);
+        }catch (Exception e) {
+            e.printStackTrace();
+            ResponseErrorDto errorDto = ResponseErrorDto.builder()
+                    .error(e.getMessage())
+                    .build();
+            return ResponseEntity.internalServerError().body(errorDto);
+        }
+    }
+
+    @PostMapping("/collection")
+    public ResponseEntity<?> createCollection(@RequestBody CollectionRequestDto dto) {
+        try {
+            CollectionResponseDto savedCollection
+                    = collectionService.createCollection(dto);
+            return ResponseEntity.ok().body(savedCollection);
         }catch (Exception e) {
             e.printStackTrace();
             ResponseErrorDto errorDto = ResponseErrorDto.builder()

--- a/src/main/java/link/sendwish/backend/dtos/CollectionRequestDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/CollectionRequestDto.java
@@ -1,0 +1,15 @@
+package link.sendwish.backend.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CollectionRequestDto {
+    private String memberId;
+    private String title;
+}

--- a/src/main/java/link/sendwish/backend/entity/Collection.java
+++ b/src/main/java/link/sendwish/backend/entity/Collection.java
@@ -13,11 +13,15 @@ import java.util.List;
 @Entity
 public class Collection extends BaseTime{
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
-    @OneToMany(mappedBy = "collection")
+    @OneToMany(mappedBy = "collection",cascade = CascadeType.ALL)
     private List<MemberCollection> memberCollections = new ArrayList<>();
 
     private String title;
+
+    public void addMemberCollection(MemberCollection memberCollection) {
+        this.memberCollections.add(memberCollection);
+    }
 }

--- a/src/main/java/link/sendwish/backend/entity/Member.java
+++ b/src/main/java/link/sendwish/backend/entity/Member.java
@@ -36,6 +36,10 @@ public class Member implements UserDetails {
     @OneToMany(mappedBy = "member")
     private List<MemberCollection> memberCollections = new ArrayList<>();
 
+    public void addMemberCollection(MemberCollection memberCollection) {
+        this.memberCollections.add(memberCollection);
+    }
+
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
         return this.roles.stream()

--- a/src/main/java/link/sendwish/backend/entity/MemberCollection.java
+++ b/src/main/java/link/sendwish/backend/entity/MemberCollection.java
@@ -1,15 +1,18 @@
 package link.sendwish.backend.entity;
 
 
-import lombok.Getter;
+import lombok.*;
 
 import javax.persistence.*;
 
 @Getter
 @Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
 public class MemberCollection {
     @Id
-    @GeneratedValue
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
     private Long id;
 
     @ManyToOne(fetch = FetchType.LAZY)

--- a/src/main/java/link/sendwish/backend/service/CollectionService.java
+++ b/src/main/java/link/sendwish/backend/service/CollectionService.java
@@ -1,11 +1,18 @@
 package link.sendwish.backend.service;
 
+import link.sendwish.backend.dtos.CollectionRequestDto;
+import link.sendwish.backend.dtos.CollectionResponseDto;
+import link.sendwish.backend.entity.Collection;
+import link.sendwish.backend.entity.Member;
+import link.sendwish.backend.entity.MemberCollection;
 import link.sendwish.backend.repository.CollectionRepository;
-import link.sendwish.backend.repository.MemberCollectionRepository;
+import link.sendwish.backend.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.ArrayList;
 
 @Service
 @RequiredArgsConstructor
@@ -14,9 +21,36 @@ import org.springframework.transaction.annotation.Transactional;
 public class CollectionService {
 
     private final CollectionRepository collectionRepository;
-    private final MemberCollectionRepository memberCollectionRepository;
+    private final MemberRepository memberRepository;
+
+    @Transactional
+    public CollectionResponseDto createCollection(CollectionRequestDto dto) {
+        Collection collection = Collection.builder()
+                .title(dto.getTitle())
+                .memberCollections(new ArrayList<>())
+
+                .build();
+
+        Member member = memberRepository.findByMemberId(dto.getMemberId()).orElseThrow(RuntimeException::new);
+        MemberCollection memberCollection = MemberCollection.builder()
+                .member(member)
+                .collection(collection)
+                .build();
+
+        /*
+        * Collection의 Cascade 옵션으로 인해 MemberCollectionRepository.save() 호출 X
+        * */
+        collectionRepository.save(collection);
+
+        member.addMemberCollection(memberCollection);
+        collection.addMemberCollection(memberCollection);
 
 
+        log.info("컬렉션 생성 [ID] : {}, [컬렉션 제목] : {}", member.getMemberId(), collection.getTitle());
 
-
+        return CollectionResponseDto.builder()
+                .memberId(member.getMemberId())
+                .title(collection.getTitle())
+                .build();
+    }
 }

--- a/src/main/java/link/sendwish/backend/service/CustomUserDetailService.java
+++ b/src/main/java/link/sendwish/backend/service/CustomUserDetailService.java
@@ -1,9 +1,7 @@
 package link.sendwish.backend.service;
 
-import link.sendwish.backend.entity.Member;
 import link.sendwish.backend.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.core.userdetails.User;
 import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;

--- a/src/main/java/link/sendwish/backend/service/MemberService.java
+++ b/src/main/java/link/sendwish/backend/service/MemberService.java
@@ -4,9 +4,7 @@ import link.sendwish.backend.auth.JwtTokenProvider;
 import link.sendwish.backend.auth.TokenInfo;
 import link.sendwish.backend.dtos.CollectionResponseDto;
 import link.sendwish.backend.dtos.MemberRequestDto;
-import link.sendwish.backend.entity.Collection;
 import link.sendwish.backend.entity.Member;
-import link.sendwish.backend.entity.MemberCollection;
 import link.sendwish.backend.repository.MemberCollectionRepository;
 import link.sendwish.backend.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
@@ -19,9 +17,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.List;
-import java.util.stream.Stream;
 
 @Service
 @Transactional(readOnly = true)
@@ -41,6 +37,7 @@ public class MemberService {
                 .memberId(dto.getMemberId())
                 .password(encode)
                 .roles(List.of("USER"))
+                .memberCollections(new ArrayList<>())
                 .build();
         Member savedMember = memberRepository.save(member);
         log.info("새로운 회원가입 [ID] : {}, [PW] : {}", savedMember.getMemberId(), savedMember.getPassword());

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,6 +19,6 @@ spring:
         show_sql: true
         dialect: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: create
 
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -5,7 +5,7 @@ server:
 
 spring:
   profiles:
-    active: dev
+    active: local
     include:
       - aws
       - auth


### PR DESCRIPTION
### 작업 개요
- `POST : /collection` api 구현
- 기능 : 사용자가 생성을 원하는 컬렉션 생성
- 생성 시 필요한 정보 : 1) string `memberId`,string `title`
- 성공 시 리턴 값 
1) string `title` - 생성된 컬렉션의 제목
2) string `memberId`- 해당 컬렉션을 생성한 유저의 `memberId`
- 구현 예시 
![스크린샷 2023-01-03 오후 8 13 51](https://user-images.githubusercontent.com/64846408/210346648-b6ba40d6-cc80-42c9-9404-3d7afc23100d.png)

### Error 1
- `@GeneratedValue`처럼 옵션을 주지 않고 사용할 경우 increase되는 ID값을 테이블들이 공유한다.
- 어느 테이블은 1,3,5 ...
- 다른 테이블은 2,4,6 ... 와 같이 ID값이 증가하는 문제 발생
- `@GeneratedValue(strategy = GenerationType.IDENTITY)` 옵션을 주어 해결

### Error 2(JPA의 Cascade 활용)
- cascade 옵션 적용 전 다대일의 관계인 두 엔티티 모두 save() 호출
- insert문 두개와 하나의 update문이 발생
- `일`에 해당하는 엔티티에 Cascade 옵션을 주어 자동으로 전파되도록 설정
- update 쿼리 사라짐

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화