### PR TITLE
refact:컬렉션 조회 함수 서비스 레이어 변경 Member -> Collection, CollectionResDto에 PK값 추가

### DIFF
--- a/src/main/java/link/sendwish/backend/controller/CollectionController.java
+++ b/src/main/java/link/sendwish/backend/controller/CollectionController.java
@@ -25,7 +25,7 @@ public class CollectionController {
     public ResponseEntity<?> getCollectionsByMember(@PathVariable("memberId") String memberId) {
         try {
             Member member = memberService.findMember(memberId);
-            List<CollectionResponseDto> memberCollection = memberService.findMemberCollection(member);
+            List<CollectionResponseDto> memberCollection = collectionService.findCollectionsByMember(member);
             return ResponseEntity.ok().body(memberCollection);
         }catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/link/sendwish/backend/dtos/CollectionResponseDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/CollectionResponseDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class CollectionResponseDto {
+    private Long collectionId;
     private String title;
     private String memberId;
     //추후 item 관련 field 추가

--- a/src/main/java/link/sendwish/backend/service/CollectionService.java
+++ b/src/main/java/link/sendwish/backend/service/CollectionService.java
@@ -6,6 +6,7 @@ import link.sendwish.backend.entity.Collection;
 import link.sendwish.backend.entity.Member;
 import link.sendwish.backend.entity.MemberCollection;
 import link.sendwish.backend.repository.CollectionRepository;
+import link.sendwish.backend.repository.MemberCollectionRepository;
 import link.sendwish.backend.repository.MemberRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -13,6 +14,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
+import java.util.List;
 
 @Service
 @RequiredArgsConstructor
@@ -22,13 +24,14 @@ public class CollectionService {
 
     private final CollectionRepository collectionRepository;
     private final MemberRepository memberRepository;
+    private final MemberCollectionRepository memberCollectionRepository;
+
 
     @Transactional
     public CollectionResponseDto createCollection(CollectionRequestDto dto) {
         Collection collection = Collection.builder()
                 .title(dto.getTitle())
                 .memberCollections(new ArrayList<>())
-
                 .build();
 
         Member member = memberRepository.findByMemberId(dto.getMemberId()).orElseThrow(RuntimeException::new);
@@ -52,5 +55,21 @@ public class CollectionService {
                 .memberId(member.getMemberId())
                 .title(collection.getTitle())
                 .build();
+    }
+
+    public List<CollectionResponseDto> findCollectionsByMember(Member member) {
+        List<CollectionResponseDto> dtos = memberCollectionRepository
+                .findAllByMember(member)
+                .orElseThrow(RuntimeException::new)
+                .stream()
+                .map(target -> CollectionResponseDto
+                        .builder()
+                        .title(target.getCollection().getTitle())
+                        .memberId(target.getMember().getUsername())
+                        .collectionId(target.getId())
+                        .build()
+                ).toList();
+        log.info("컬렉션 일괄 조회 [ID] : {}, [컬렉션 갯수] : {}", member.getMemberId(), dtos.size());
+        return dtos;
     }
 }

--- a/src/main/java/link/sendwish/backend/service/MemberService.java
+++ b/src/main/java/link/sendwish/backend/service/MemberService.java
@@ -28,7 +28,6 @@ public class MemberService {
     private final AuthenticationManagerBuilder authenticationManagerBuilder;
     private final JwtTokenProvider jwtTokenProvider;
     private final PasswordEncoder passwordEncoder;
-    private final MemberCollectionRepository memberCollectionRepository;
 
     @Transactional
     public Member createMember(MemberRequestDto dto) {
@@ -57,18 +56,5 @@ public class MemberService {
 
     public Member findMember(String memberId) {
         return memberRepository.findByMemberId(memberId).orElseThrow(RuntimeException::new);
-    }
-
-    public List<CollectionResponseDto> findMemberCollection(Member member) {
-        return memberCollectionRepository
-                .findAllByMember(member)
-                .orElseThrow(RuntimeException::new)
-                .stream()
-                .map(target -> CollectionResponseDto
-                        .builder()
-                        .title(target.getCollection().getTitle())
-                        .memberId(target.getMember().getUsername())
-                        .build()
-                ).toList();
     }
 }


### PR DESCRIPTION
### 작업 개요
- 컬렉션 조회 함수의 Service 레이어 변경(MemberService to CollectionService)
- 멤버의 컬렉션 조회시, 해당 컬렉션의 PK 값을 함께 client에게 전달
- 추후에 해당 컬렉션을 조회 시, 사용 가능(GET : /collection/{collectionId})

### 작업 분류
- [ ] 버그 수정
- [ ] 신규 기능
- [x] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화