### PR TITLE
feat:컬렉션 제목 수정 api 구현

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,4 +2,4 @@ FROM openjdk:16-jdk-slim
 EXPOSE 8081
 ARG JAR_FILE=./build/libs/backend-0.0.1-SNAPSHOT.jar
 COPY ${JAR_FILE} app.jar
-ENTRYPOINT ["java","-jar","-Dspring.profiels,active=dev","/app.jar"]
+ENTRYPOINT ["java","-jar","-Dspring.profiles.active=dev","/app.jar"]

--- a/src/main/java/link/sendwish/backend/controller/CollectionController.java
+++ b/src/main/java/link/sendwish/backend/controller/CollectionController.java
@@ -1,8 +1,10 @@
 package link.sendwish.backend.controller;
 
-import link.sendwish.backend.dtos.CollectionRequestDto;
+import link.sendwish.backend.dtos.CollectionCreateRequestDto;
+import link.sendwish.backend.dtos.CollectionUpdateRequestDto;
 import link.sendwish.backend.dtos.CollectionResponseDto;
 import link.sendwish.backend.dtos.ResponseErrorDto;
+import link.sendwish.backend.entity.Collection;
 import link.sendwish.backend.entity.Member;
 import link.sendwish.backend.service.CollectionService;
 import link.sendwish.backend.service.MemberService;
@@ -37,7 +39,7 @@ public class CollectionController {
     }
 
     @PostMapping("/collection")
-    public ResponseEntity<?> createCollection(@RequestBody CollectionRequestDto dto) {
+    public ResponseEntity<?> createCollection(@RequestBody CollectionCreateRequestDto dto) {
         try {
             CollectionResponseDto savedCollection
                     = collectionService.createCollection(dto);
@@ -51,5 +53,22 @@ public class CollectionController {
         }
     }
 
+    @PatchMapping("/collection")
+    public ResponseEntity<?> updateCollectionTile(@RequestBody CollectionUpdateRequestDto dto) {
+        try {
+            if (dto.getNewTitle() == null || dto.getMemberId() == null || dto.getCollectionId() == null) {
+                throw new RuntimeException("잘못된 DTO 요청입니다.");
+            }
+            Collection find = collectionService.findCollection(dto.getCollectionId(),dto.getMemberId());
+            CollectionResponseDto responseDto = collectionService.updateCollectionTitle(find, dto);
+            return ResponseEntity.ok().body(responseDto);
+        }catch (Exception e) {
+            e.printStackTrace();
+            ResponseErrorDto errorDto = ResponseErrorDto.builder()
+                    .error(e.getMessage())
+                    .build();
+            return ResponseEntity.internalServerError().body(errorDto);
+        }
+    }
 
 }

--- a/src/main/java/link/sendwish/backend/dtos/CollectionCreateRequestDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/CollectionCreateRequestDto.java
@@ -1,0 +1,15 @@
+package link.sendwish.backend.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CollectionCreateRequestDto {
+    private String memberId;
+    private String title;
+}

--- a/src/main/java/link/sendwish/backend/dtos/CollectionUpdateRequestDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/CollectionUpdateRequestDto.java
@@ -9,7 +9,8 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class CollectionRequestDto {
+public class CollectionUpdateRequestDto {
     private String memberId;
-    private String title;
+    private String newTitle;
+    private Long collectionId;
 }

--- a/src/main/java/link/sendwish/backend/entity/Collection.java
+++ b/src/main/java/link/sendwish/backend/entity/Collection.java
@@ -24,4 +24,8 @@ public class Collection extends BaseTime{
     public void addMemberCollection(MemberCollection memberCollection) {
         this.memberCollections.add(memberCollection);
     }
+
+    public void changeTitle(String newTitle) {
+        this.title = newTitle;
+    }
 }


### PR DESCRIPTION
### 작업 개요
- 컬렉션 제목 수정 api 구현
- `CollectionUpdateRequestDto`이 JSON 형태로 요청이 들어올 경우, 해당 dto의 newTitle로 기존의 존재하는 컬렉션의 제목을 변경
- JPA Dirty-Checking 사용
- API : `PATCH /collection`

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화