### PR TITLE
feat:Item 엔티티 생성,컬렉션 상세조회,Item Mock 데이터 생성 구현

### DIFF
--- a/src/main/java/link/sendwish/backend/config/SecurityConfig.java
+++ b/src/main/java/link/sendwish/backend/config/SecurityConfig.java
@@ -30,6 +30,9 @@ public class SecurityConfig {
                 .antMatchers("/signin").permitAll()
                 .antMatchers("/signup").permitAll()
                 .antMatchers("/").permitAll()
+                .antMatchers("/collections/**").permitAll()
+                .antMatchers("/collection/**").permitAll()
+                .antMatchers("/item/**").permitAll()
                 .anyRequest().authenticated()
                 .and()
                 .addFilterBefore(new JwtAuthenticationFilter(jwtTokenProvider), UsernamePasswordAuthenticationFilter.class);

--- a/src/main/java/link/sendwish/backend/controller/CollectionController.java
+++ b/src/main/java/link/sendwish/backend/controller/CollectionController.java
@@ -1,9 +1,6 @@
 package link.sendwish.backend.controller;
 
-import link.sendwish.backend.dtos.CollectionCreateRequestDto;
-import link.sendwish.backend.dtos.CollectionUpdateRequestDto;
-import link.sendwish.backend.dtos.CollectionResponseDto;
-import link.sendwish.backend.dtos.ResponseErrorDto;
+import link.sendwish.backend.dtos.*;
 import link.sendwish.backend.entity.Collection;
 import link.sendwish.backend.entity.Member;
 import link.sendwish.backend.service.CollectionService;
@@ -62,6 +59,22 @@ public class CollectionController {
             Collection find = collectionService.findCollection(dto.getCollectionId(),dto.getMemberId());
             CollectionResponseDto responseDto = collectionService.updateCollectionTitle(find, dto);
             return ResponseEntity.ok().body(responseDto);
+        }catch (Exception e) {
+            e.printStackTrace();
+            ResponseErrorDto errorDto = ResponseErrorDto.builder()
+                    .error(e.getMessage())
+                    .build();
+            return ResponseEntity.internalServerError().body(errorDto);
+        }
+    }
+
+    @GetMapping("/collection/{memberId}/{collectionId}")
+    public ResponseEntity<?> getDetailCollection(@PathVariable("memberId") String memberId,
+                                                 @PathVariable("collectionId") Long collectionId) {
+        try {
+            Collection collection = collectionService.findCollection(collectionId,memberId);
+            CollectionDetailResponseDto dto = collectionService.getDetails(collection, memberId);
+            return ResponseEntity.ok().body(dto);
         }catch (Exception e) {
             e.printStackTrace();
             ResponseErrorDto errorDto = ResponseErrorDto.builder()

--- a/src/main/java/link/sendwish/backend/controller/ItemController.java
+++ b/src/main/java/link/sendwish/backend/controller/ItemController.java
@@ -1,0 +1,70 @@
+package link.sendwish.backend.controller;
+
+import link.sendwish.backend.dtos.ItemCreateRequestDto;
+import link.sendwish.backend.dtos.ItemEnrollmentRequestDto;
+import link.sendwish.backend.dtos.ItemResponseDto;
+import link.sendwish.backend.dtos.ResponseErrorDto;
+import link.sendwish.backend.entity.Collection;
+import link.sendwish.backend.entity.Item;
+import link.sendwish.backend.service.CollectionService;
+import link.sendwish.backend.service.ItemService;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@Slf4j
+@RequiredArgsConstructor
+@RestController
+@RequestMapping("/item")
+public class ItemController {
+
+    private final ItemService itemService;
+    private final CollectionService collectionService;
+
+    //등록된 item id 값 리턴
+    @PostMapping("/parsing")
+    public ResponseEntity<?> createItem(/*@RequestBody ItemCreateRequestDto dto*/) {
+        try {
+            /*
+            * Python Server 호출, DB에 Item 등록
+            * */
+            Item item = Item.builder()
+                    .name("석유의 종말은 없다")
+                    .price(20700)
+                    .imgUrl("https://test/12adfasd3")
+                    .build();
+            Long saveItem = itemService.saveItem(item);
+
+            return ResponseEntity.ok().body(saveItem);
+        }catch (Exception e) {
+            e.printStackTrace();
+            ResponseErrorDto errorDto = ResponseErrorDto.builder()
+                    .error(e.getMessage())
+                    .build();
+            return ResponseEntity.internalServerError().body(errorDto);
+        }
+    }
+
+    @PostMapping("/enrollment")
+    public ResponseEntity<?> enrollItem(@RequestBody ItemEnrollmentRequestDto dto) {
+        try {
+            /*
+            * find Collection 후 , Item 찾아서 (JPA 1차 캐시) 해당 Item을 Collection에 저장
+            * 하고 나서 해당 item 상세 정보를 return
+            * */
+            Collection collection = collectionService.findCollection(dto.getCollectionId(), dto.getMemberId());
+            ItemResponseDto itemResponseDto = itemService.enrollItemToCollection(collection, dto.getItemId());
+            return ResponseEntity.ok().body(itemResponseDto);
+        }catch (Exception e) {
+            e.printStackTrace();
+            ResponseErrorDto errorDto = ResponseErrorDto.builder()
+                    .error(e.getMessage())
+                    .build();
+            return ResponseEntity.internalServerError().body(errorDto);
+        }
+    }
+}

--- a/src/main/java/link/sendwish/backend/dtos/CollectionDetailResponseDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/CollectionDetailResponseDto.java
@@ -1,0 +1,18 @@
+package link.sendwish.backend.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.util.List;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CollectionDetailResponseDto {
+    List<ItemResponseDto> dtos;
+    Long collectionId;
+    String memberId;
+}

--- a/src/main/java/link/sendwish/backend/dtos/ItemCreateRequestDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/ItemCreateRequestDto.java
@@ -1,0 +1,14 @@
+package link.sendwish.backend.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemCreateRequestDto {
+    private String url;
+}

--- a/src/main/java/link/sendwish/backend/dtos/ItemEnrollmentRequestDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/ItemEnrollmentRequestDto.java
@@ -1,0 +1,16 @@
+package link.sendwish.backend.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemEnrollmentRequestDto {
+    private Long itemId;
+    private Long collectionId;
+    private String memberId;
+}

--- a/src/main/java/link/sendwish/backend/dtos/ItemResponseDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/ItemResponseDto.java
@@ -1,0 +1,16 @@
+package link.sendwish.backend.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ItemResponseDto {
+    private int price;
+    private String name;
+    private String imgUrl;
+}

--- a/src/main/java/link/sendwish/backend/entity/Collection.java
+++ b/src/main/java/link/sendwish/backend/entity/Collection.java
@@ -19,10 +19,17 @@ public class Collection extends BaseTime{
     @OneToMany(mappedBy = "collection",cascade = CascadeType.ALL)
     private List<MemberCollection> memberCollections = new ArrayList<>();
 
+    @OneToMany(mappedBy = "collection", cascade = CascadeType.ALL)
+    private List<CollectionItem> collectionItems = new ArrayList<>();
+
     private String title;
 
     public void addMemberCollection(MemberCollection memberCollection) {
         this.memberCollections.add(memberCollection);
+    }
+
+    public void addCollectionItem(CollectionItem collectionItem) {
+        this.collectionItems.add(collectionItem);
     }
 
     public void changeTitle(String newTitle) {

--- a/src/main/java/link/sendwish/backend/entity/CollectionItem.java
+++ b/src/main/java/link/sendwish/backend/entity/CollectionItem.java
@@ -1,0 +1,24 @@
+package link.sendwish.backend.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+
+@Getter
+@Entity
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+public class CollectionItem {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "colletion_id")
+    private Collection collection;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "item_id")
+    private Item item;
+}

--- a/src/main/java/link/sendwish/backend/entity/Item.java
+++ b/src/main/java/link/sendwish/backend/entity/Item.java
@@ -1,0 +1,33 @@
+package link.sendwish.backend.entity;
+
+import lombok.*;
+
+import javax.persistence.*;
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@Builder
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@AllArgsConstructor
+@Entity
+public class Item {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String name;
+
+    @Column(nullable = false)
+    private int price;
+
+    private String imgUrl;
+
+    @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
+    private List<CollectionItem> collectionItems = new ArrayList<>();
+
+    public void addCollectionItem(CollectionItem collectionItem) {
+        this.collectionItems.add(collectionItem);
+    }
+}

--- a/src/main/java/link/sendwish/backend/repository/ItemRepository.java
+++ b/src/main/java/link/sendwish/backend/repository/ItemRepository.java
@@ -1,0 +1,8 @@
+package link.sendwish.backend.repository;
+
+import link.sendwish.backend.entity.Item;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface ItemRepository extends JpaRepository<Item, Long> {
+
+}

--- a/src/main/java/link/sendwish/backend/service/CollectionService.java
+++ b/src/main/java/link/sendwish/backend/service/CollectionService.java
@@ -1,11 +1,7 @@
 package link.sendwish.backend.service;
 
-import link.sendwish.backend.dtos.CollectionCreateRequestDto;
-import link.sendwish.backend.dtos.CollectionUpdateRequestDto;
-import link.sendwish.backend.dtos.CollectionResponseDto;
-import link.sendwish.backend.entity.Collection;
-import link.sendwish.backend.entity.Member;
-import link.sendwish.backend.entity.MemberCollection;
+import link.sendwish.backend.dtos.*;
+import link.sendwish.backend.entity.*;
 import link.sendwish.backend.repository.CollectionRepository;
 import link.sendwish.backend.repository.MemberCollectionRepository;
 import link.sendwish.backend.repository.MemberRepository;
@@ -48,7 +44,7 @@ public class CollectionService {
         collectionRepository.save(collection);
 
         member.addMemberCollection(memberCollection);
-        collection.addMemberCollection(memberCollection);
+        collection.addMemberCollection(memberCollection);//Cascade Option으로 insert문 자동 호출
 
 
         log.info("컬렉션 생성 [ID] : {}, [컬렉션 제목] : {}", member.getMemberId(), collection.getTitle());
@@ -79,6 +75,21 @@ public class CollectionService {
         Collection find = collectionRepository.findById(collectionId).orElseThrow(RuntimeException::new);
         log.info("컬렉션 단건 조회 [ID] : {}, [컬렉션 제목] : {}", memberId, find.getTitle());
         return find;
+    }
+
+    public CollectionDetailResponseDto getDetails(Collection collection,String memberId) {
+        List<Item> items = collection.getCollectionItems()
+                .stream().map(CollectionItem::getItem).toList();
+        return CollectionDetailResponseDto.builder()
+                .collectionId(collection.getId())
+                .memberId(memberId)
+                .dtos(items.stream().map(
+                        target -> ItemResponseDto.builder()
+                                .price(target.getPrice())
+                                .name(target.getName())
+                                .imgUrl(target.getImgUrl())
+                                .build()
+                ).toList()).build();
     }
 
     @Transactional

--- a/src/main/java/link/sendwish/backend/service/ItemService.java
+++ b/src/main/java/link/sendwish/backend/service/ItemService.java
@@ -1,0 +1,46 @@
+package link.sendwish.backend.service;
+
+
+import link.sendwish.backend.dtos.ItemResponseDto;
+import link.sendwish.backend.entity.Collection;
+import link.sendwish.backend.entity.CollectionItem;
+import link.sendwish.backend.entity.Item;
+import link.sendwish.backend.repository.ItemRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+@Slf4j
+public class ItemService {
+
+    private final ItemRepository itemRepository;
+
+    @Transactional
+    public Long saveItem(Item item) {
+        Item save = itemRepository.save(item);
+
+        return save.getId();
+    }
+
+    @Transactional
+    public ItemResponseDto enrollItemToCollection(Collection collection, Long itemId) {
+        Item item = itemRepository.findById(itemId).orElseThrow(RuntimeException::new);
+        CollectionItem collectionItem = CollectionItem.builder()
+                .item(item)
+                .collection(collection)
+                .build();
+
+        item.addCollectionItem(collectionItem);
+        collection.addCollectionItem(collectionItem);//Cascade Option으로 insert문 자동 호출
+
+        return ItemResponseDto.builder()
+                .imgUrl(item.getImgUrl())
+                .name(item.getName())
+                .price(item.getPrice())
+                .build();
+    }
+}


### PR DESCRIPTION
### 작업 개요
- getDetailCollection()메서드 : 사용자의 컬렉션 클릭할 경우 필요할 데이터 서빙(해당 컬렉션 내의 아이템들의 정보)
- createItem : 가짜 Item 객체 생성해준다
- enrollItem : 가짜 Item을 사용자가 선택한 컬렉션에 등록해준다

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화