### PR TITLE
feat: python scrap server 연결, response에 originalUrl, collectionId 추가

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -35,6 +35,9 @@ dependencies {
 	//DB
 	runtimeOnly 'mysql:mysql-connector-java'
 	runtimeOnly 'com.h2database:h2'
+
+	//json
+	implementation 'org.json:json:20200518'
 }
 
 tasks.named('test') {

--- a/src/main/java/link/sendwish/backend/dtos/ItemResponseDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/ItemResponseDto.java
@@ -13,4 +13,5 @@ public class ItemResponseDto {
     private int price;
     private String name;
     private String imgUrl;
+    private String originUrl;
 }

--- a/src/main/java/link/sendwish/backend/entity/Item.java
+++ b/src/main/java/link/sendwish/backend/entity/Item.java
@@ -24,6 +24,8 @@ public class Item {
 
     private String imgUrl;
 
+    private String originUrl;
+
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
     private List<CollectionItem> collectionItems = new ArrayList<>();
 

--- a/src/main/java/link/sendwish/backend/service/CollectionService.java
+++ b/src/main/java/link/sendwish/backend/service/CollectionService.java
@@ -52,6 +52,7 @@ public class CollectionService {
         return CollectionResponseDto.builder()
                 .memberId(member.getMemberId())
                 .title(collection.getTitle())
+                .collectionId(collection.getId())
                 .build();
     }
 

--- a/src/main/java/link/sendwish/backend/service/ItemService.java
+++ b/src/main/java/link/sendwish/backend/service/ItemService.java
@@ -41,6 +41,7 @@ public class ItemService {
                 .imgUrl(item.getImgUrl())
                 .name(item.getName())
                 .price(item.getPrice())
+                .originUrl(item.getOriginUrl())
                 .build();
     }
 }


### PR DESCRIPTION
### 작업 개요
- python scrap server 연결
- client로부터 받은 url을 python scrap server로 post 요청시 url, name, price, imgUrl 응답 받도록 구현
- 응답받은 데이터 객체 JSONobject는 db에 저장

- "item/enrollment" api response에 originalUrl, collectionId 추가

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화