### PR TITLE
feat:addFriend, findCollectionByMember, deleteCollection

### DIFF
--- a/src/main/java/link/sendwish/backend/common/Messages.java
+++ b/src/main/java/link/sendwish/backend/common/Messages.java
@@ -10,6 +10,7 @@ public class Messages {
     public static final String NO_MEMBER_COLLECTION_MESSAGE = "멤버 콜렉션이 존재하지 않습니다.";
     public static final String SAME_MEMBER_ID_MESSAGE = "이미 존재하는 아이디입니다.";
     public static final String SAME_COLLECTION_TITLE_MESSAGE = "수정하려는 제목이 동일합니다.";
+    public static final String SAME_FRIEND_ID_MESSAGE = "이미 존재하는 친구입니다.";
     public static final String PASSWORD_NOT_EQUAL = "비밀번호가 일치하지 않습니다.";
     public static final String DTO_NULL_MESSAGE = "잘못된 DTO 요청입니다.";
 

--- a/src/main/java/link/sendwish/backend/common/Messages.java
+++ b/src/main/java/link/sendwish/backend/common/Messages.java
@@ -11,7 +11,9 @@ public class Messages {
     public static final String SAME_MEMBER_ID_MESSAGE = "이미 존재하는 아이디입니다.";
     public static final String SAME_COLLECTION_TITLE_MESSAGE = "수정하려는 제목이 동일합니다.";
     public static final String SAME_FRIEND_ID_MESSAGE = "이미 존재하는 친구입니다.";
+    public static final String NOT_DELETE_COLLECTION = "콜렉션이 삭제되지 않았습니다.";
     public static final String PASSWORD_NOT_EQUAL = "비밀번호가 일치하지 않습니다.";
+
     public static final String DTO_NULL_MESSAGE = "잘못된 DTO 요청입니다.";
 
 

--- a/src/main/java/link/sendwish/backend/common/Messages.java
+++ b/src/main/java/link/sendwish/backend/common/Messages.java
@@ -5,16 +5,20 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class Messages {
     public static final String NO_USER_MESSAGE = "존재하지 않는 사용자입니다.";
-    public static final String SAME_MEMBER_ID_MESSAGE = "이미 존재하는 아이디입니다.";
-    public static final String PASSWORD_NOT_EQUAL = "비밀번호가 일치하지 않습니다.";
-
     public static final String NO_COLLECTION_MESSAGE = "콜렉션이 존재하지 않습니다.";
-
-    public static final String SAME_COLLECTION_TITLE_MESSAGE = "수정하려는 제목이 동일합니다.";
-
     public static final String NO_ITEM_MESSAGE = "아이템이 존재하지 않습니다.";
     public static final String NO_MEMBER_COLLECTION_MESSAGE = "멤버 콜렉션이 존재하지 않습니다.";
+    public static final String SAME_MEMBER_ID_MESSAGE = "이미 존재하는 아이디입니다.";
+    public static final String SAME_COLLECTION_TITLE_MESSAGE = "수정하려는 제목이 동일합니다.";
+    public static final String PASSWORD_NOT_EQUAL = "비밀번호가 일치하지 않습니다.";
     public static final String DTO_NULL_MESSAGE = "잘못된 DTO 요청입니다.";
+
+
+
+
+
+
+
 
 
 

--- a/src/main/java/link/sendwish/backend/common/exception/CollectionNotDeleteException.java
+++ b/src/main/java/link/sendwish/backend/common/exception/CollectionNotDeleteException.java
@@ -1,0 +1,9 @@
+package link.sendwish.backend.common.exception;
+
+import link.sendwish.backend.common.Messages;
+
+public class CollectionNotDeleteException extends BusinessException{
+    public CollectionNotDeleteException() {
+        super(Messages.NOT_DELETE_COLLECTION);
+    }
+}

--- a/src/main/java/link/sendwish/backend/common/exception/MemberFriendExistingException.java
+++ b/src/main/java/link/sendwish/backend/common/exception/MemberFriendExistingException.java
@@ -1,0 +1,9 @@
+package link.sendwish.backend.common.exception;
+
+import link.sendwish.backend.common.Messages;
+
+public class MemberFriendExistingException extends BusinessException{
+    public MemberFriendExistingException() {
+        super(Messages.SAME_FRIEND_ID_MESSAGE);
+    }
+}

--- a/src/main/java/link/sendwish/backend/controller/CollectionController.java
+++ b/src/main/java/link/sendwish/backend/controller/CollectionController.java
@@ -25,7 +25,9 @@ public class CollectionController {
     public ResponseEntity<?> getCollectionsByMember(@PathVariable("nickname") String nickname) {
         try {
             Member member = memberService.findMember(nickname);
+
             List<CollectionResponseDto> memberCollection = collectionService.findCollectionsByMember(member);
+
             return ResponseEntity.ok().body(memberCollection);
         }catch (Exception e) {
             e.printStackTrace();

--- a/src/main/java/link/sendwish/backend/controller/CollectionController.java
+++ b/src/main/java/link/sendwish/backend/controller/CollectionController.java
@@ -90,4 +90,21 @@ public class CollectionController {
         }
     }
 
+    @DeleteMapping("/collection/{nickname}/{collectionId}")
+    public ResponseEntity<?> deleteCollection(@PathVariable("nickname") String nickname,
+                                              @PathVariable("collectionId") Long collectionId) {
+        try {
+            CollectionResponseDto dtos = collectionService.deleteCollection(collectionId, nickname);
+            return ResponseEntity.ok().body(dtos);
+        }catch (Exception e) {
+            e.printStackTrace();
+            ResponseErrorDto errorDto = ResponseErrorDto.builder()
+                    .error(e.getMessage())
+                    .build();
+            return ResponseEntity.internalServerError().body(errorDto);
+        }
+    }
+
+
+
 }

--- a/src/main/java/link/sendwish/backend/controller/MemberController.java
+++ b/src/main/java/link/sendwish/backend/controller/MemberController.java
@@ -3,6 +3,7 @@ package link.sendwish.backend.controller;
 
 import link.sendwish.backend.auth.TokenInfo;
 import link.sendwish.backend.common.exception.DtoNullException;
+import link.sendwish.backend.dtos.MemberFriendAddRequestDto;
 import link.sendwish.backend.dtos.ResponseErrorDto;
 import link.sendwish.backend.dtos.MemberRequestDto;
 import link.sendwish.backend.dtos.MemberResponseDto;
@@ -31,7 +32,7 @@ public class MemberController {
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody MemberRequestDto dto) {
         try {
-            if(dto.getNickname() == null || dto.getPassword() == null){
+            if (dto.getNickname() == null || dto.getPassword() == null) {
                 throw new DtoNullException();
             }
             log.info("id = {}", dto.getNickname());
@@ -53,12 +54,33 @@ public class MemberController {
     @PostMapping("signin")
     public ResponseEntity<?> signin(@RequestBody MemberRequestDto dto) {
         try {
-            if (dto.getNickname() == null || dto.getPassword() == null){
+            if (dto.getNickname() == null || dto.getPassword() == null) {
                 throw new DtoNullException();
             }
             TokenInfo tokenInfo = memberService.login(dto.getNickname(), dto.getPassword());
             return ResponseEntity.ok().body(tokenInfo);
-        }catch (Exception e) {
+        } catch (Exception e) {
+            e.printStackTrace();
+            ResponseErrorDto errorDto = ResponseErrorDto.builder()
+                    .error(e.getMessage())
+                    .build();
+            return ResponseEntity.internalServerError().body(errorDto);
+        }
+    }
+
+    @PostMapping("/add/friend")
+    public ResponseEntity<?> addFriend(@RequestBody MemberFriendAddRequestDto dto) {
+        try {
+            if (dto.getMemberId() == null || dto.getAddMemberId() == null) {
+                throw new DtoNullException();
+            }
+            Member friendMember = memberService.addFriendToMe(dto);
+            MemberResponseDto returnDto = MemberResponseDto.builder()
+                    .id(friendMember.getId())
+                    .nickname(friendMember.getNickname())
+                    .build();
+            return ResponseEntity.ok().body(returnDto);
+        } catch (Exception e) {
             e.printStackTrace();
             ResponseErrorDto errorDto = ResponseErrorDto.builder()
                     .error(e.getMessage())

--- a/src/main/java/link/sendwish/backend/controller/MemberController.java
+++ b/src/main/java/link/sendwish/backend/controller/MemberController.java
@@ -3,10 +3,7 @@ package link.sendwish.backend.controller;
 
 import link.sendwish.backend.auth.TokenInfo;
 import link.sendwish.backend.common.exception.DtoNullException;
-import link.sendwish.backend.dtos.MemberFriendAddRequestDto;
-import link.sendwish.backend.dtos.ResponseErrorDto;
-import link.sendwish.backend.dtos.MemberRequestDto;
-import link.sendwish.backend.dtos.MemberResponseDto;
+import link.sendwish.backend.dtos.*;
 import link.sendwish.backend.entity.Member;
 import link.sendwish.backend.service.MemberService;
 import lombok.RequiredArgsConstructor;
@@ -32,7 +29,7 @@ public class MemberController {
     @PostMapping("/signup")
     public ResponseEntity<?> signup(@RequestBody MemberRequestDto dto) {
         try {
-            if (dto.getNickname() == null || dto.getPassword() == null) {
+            if (dto.getNickname() == null || dto.getPassword() == null || dto.getNickname() == "" || dto.getPassword() == "") {
                 throw new DtoNullException();
             }
             log.info("id = {}", dto.getNickname());
@@ -74,12 +71,10 @@ public class MemberController {
             if (dto.getMemberId() == null || dto.getAddMemberId() == null) {
                 throw new DtoNullException();
             }
-            Member friendMember = memberService.addFriendToMe(dto);
-            MemberResponseDto returnDto = MemberResponseDto.builder()
-                    .id(friendMember.getId())
-                    .nickname(friendMember.getNickname())
-                    .build();
-            return ResponseEntity.ok().body(returnDto);
+
+            MemberFriendAddResponseDto dtos = memberService.addFriendToMe(dto);
+
+            return ResponseEntity.ok().body(dtos);
         } catch (Exception e) {
             e.printStackTrace();
             ResponseErrorDto errorDto = ResponseErrorDto.builder()

--- a/src/main/java/link/sendwish/backend/dtos/CollectionDeleteRequestDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/CollectionDeleteRequestDto.java
@@ -1,0 +1,15 @@
+package link.sendwish.backend.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class CollectionDeleteRequestDto {
+    private String nickname;
+    private Long collectionId;
+}

--- a/src/main/java/link/sendwish/backend/dtos/MemberFriendAddRequestDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/MemberFriendAddRequestDto.java
@@ -1,0 +1,15 @@
+package link.sendwish.backend.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberFriendAddRequestDto {
+    private Long memberId; // 친구를 추가할 본인의 memberId
+    private Long addMemberId; // 추가할 친구의 memberId
+}

--- a/src/main/java/link/sendwish/backend/dtos/MemberFriendAddResponseDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/MemberFriendAddResponseDto.java
@@ -1,0 +1,15 @@
+package link.sendwish.backend.dtos;
+
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class MemberFriendAddResponseDto {
+    private String nickname; // my nickname
+    private String friendNickname; // friend nickname
+}

--- a/src/main/java/link/sendwish/backend/entity/Collection.java
+++ b/src/main/java/link/sendwish/backend/entity/Collection.java
@@ -24,6 +24,9 @@ public class Collection extends BaseTime{
 
     private String title;
 
+    @Builder.Default
+    private int reference = 1;
+
     public void addMemberCollection(MemberCollection memberCollection) {
         this.memberCollections.add(memberCollection);
     }
@@ -34,5 +37,13 @@ public class Collection extends BaseTime{
 
     public void changeTitle(String newTitle) {
         this.title = newTitle;
+    }
+
+    public void addReference() {
+        this.reference += 1;
+    }
+
+    public void subtractReference() {
+        this.reference -= 1;
     }
 }

--- a/src/main/java/link/sendwish/backend/entity/Collection.java
+++ b/src/main/java/link/sendwish/backend/entity/Collection.java
@@ -31,6 +31,10 @@ public class Collection extends BaseTime{
         this.memberCollections.add(memberCollection);
     }
 
+    public void deleteMemberCollection(MemberCollection memberCollection) {
+        this.memberCollections.remove(memberCollection);
+    }
+
     public void addCollectionItem(CollectionItem collectionItem) {
         this.collectionItems.add(collectionItem);
     }

--- a/src/main/java/link/sendwish/backend/entity/Member.java
+++ b/src/main/java/link/sendwish/backend/entity/Member.java
@@ -44,6 +44,10 @@ public class Member implements UserDetails {
         this.memberCollections.add(memberCollection);
     }
 
+    public void deleteMemberCollection(MemberCollection memberCollection) {
+        this.memberCollections.remove(memberCollection);
+    }
+
     public void addFriendInList(Member friend){ this.friends.add(friend); }
 
     @Override

--- a/src/main/java/link/sendwish/backend/entity/Member.java
+++ b/src/main/java/link/sendwish/backend/entity/Member.java
@@ -1,5 +1,6 @@
 package link.sendwish.backend.entity;
 
+import link.sendwish.backend.repository.MemberRepository;
 import lombok.*;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.authority.SimpleGrantedAuthority;
@@ -36,8 +37,15 @@ public class Member implements UserDetails {
     @OneToMany(mappedBy = "member")
     private List<MemberCollection> memberCollections = new ArrayList<>();
 
+    @OneToMany(mappedBy = "member")
+    private List<Member> friends = new ArrayList<>();
+
     public void addMemberCollection(MemberCollection memberCollection) {
         this.memberCollections.add(memberCollection);
+    }
+
+    public void addFriendInList(Member friends){
+        this.friends.add(friends);
     }
 
     @Override

--- a/src/main/java/link/sendwish/backend/entity/Member.java
+++ b/src/main/java/link/sendwish/backend/entity/Member.java
@@ -37,16 +37,14 @@ public class Member implements UserDetails {
     @OneToMany(mappedBy = "member")
     private List<MemberCollection> memberCollections = new ArrayList<>();
 
-    @OneToMany(mappedBy = "member")
+    @OneToMany
     private List<Member> friends = new ArrayList<>();
 
     public void addMemberCollection(MemberCollection memberCollection) {
         this.memberCollections.add(memberCollection);
     }
 
-    public void addFriendInList(Member friends){
-        this.friends.add(friends);
-    }
+    public void addFriendInList(Member friend){ this.friends.add(friend); }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {

--- a/src/main/java/link/sendwish/backend/repository/CollectionRepository.java
+++ b/src/main/java/link/sendwish/backend/repository/CollectionRepository.java
@@ -4,6 +4,8 @@ import link.sendwish.backend.entity.Collection;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface CollectionRepository extends JpaRepository<Collection,Long> {
 

--- a/src/main/java/link/sendwish/backend/repository/MemberCollectionRepository.java
+++ b/src/main/java/link/sendwish/backend/repository/MemberCollectionRepository.java
@@ -1,5 +1,6 @@
 package link.sendwish.backend.repository;
 
+import link.sendwish.backend.entity.Collection;
 import link.sendwish.backend.entity.Member;
 import link.sendwish.backend.entity.MemberCollection;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,7 @@ import java.util.Optional;
 
 public interface MemberCollectionRepository extends JpaRepository<MemberCollection, Long> {
     Optional<List<MemberCollection>> findAllByMember(Member member);
+    Optional<MemberCollection> findByMemberAndCollection(Member member, Collection collection);
+
+    void deleteByMemberAndCollection(Member member, Collection collection);
 }

--- a/src/main/java/link/sendwish/backend/repository/MemberRepository.java
+++ b/src/main/java/link/sendwish/backend/repository/MemberRepository.java
@@ -8,5 +8,5 @@ import java.util.Optional;
 
 @Repository
 public interface MemberRepository extends JpaRepository<Member,Long> {
-    Optional<Member> findBynickname(String nickname);
+    Optional<Member> findByNickname(String nickname);
 }

--- a/src/main/java/link/sendwish/backend/service/CollectionService.java
+++ b/src/main/java/link/sendwish/backend/service/CollectionService.java
@@ -1,9 +1,6 @@
 package link.sendwish.backend.service;
 
-import link.sendwish.backend.common.exception.CollectionSameTitleException;
-import link.sendwish.backend.common.exception.MemberNotFoundException;
-import link.sendwish.backend.common.exception.CollectionNotFoundException;
-import link.sendwish.backend.common.exception.MemberCollectionNotFoundException;
+import link.sendwish.backend.common.exception.*;
 import link.sendwish.backend.dtos.*;
 import link.sendwish.backend.entity.*;
 import link.sendwish.backend.repository.CollectionRepository;
@@ -112,6 +109,47 @@ public class CollectionService {
         return CollectionResponseDto.builder()
                 .title(findByCache.getTitle())
                 .nickname(dto.getNickname())
+                .build();
+    }
+
+    @Transactional
+    public CollectionResponseDto deleteCollection(Long collectionId, String nickname) {
+
+        Member member = memberRepository.findByNickname(nickname)
+                                        .orElseThrow(MemberNotFoundException::new);
+        Collection collection = collectionRepository.findById(collectionId)
+                                                    .orElseThrow(CollectionNotFoundException::new);
+
+        MemberCollection memberCollection = memberCollectionRepository
+                                            .findByMemberAndCollection(member, collection)
+                                            .orElseThrow(MemberCollectionNotFoundException::new);
+
+        memberCollectionRepository.deleteByMemberAndCollection(member, collection);
+
+
+        // reference가 1일시 => 컬렉션 삭제 (Cascade 옵션 고려)
+        if(collection.getReference() == 1) {
+            collectionRepository.delete(collection);
+            if (collectionRepository.findById(collectionId).isPresent()) {
+                throw new CollectionNotDeleteException();
+            }
+        }
+
+        // reference가 1이 아닐시
+        else {
+            collection.subtractReference();
+            member.deleteMemberCollection(memberCollection);
+            collection.deleteMemberCollection(memberCollection);
+            assert(collection.getReference() == memberCollection.getCollection().getReference());
+        }
+
+        log.info("컬렉션 멤버에서 삭제 [ID] : {}, [Title] : {}, [nickname] : {}",
+                collection.getId(), collection.getTitle(), member.getNickname());
+
+        return CollectionResponseDto.builder()
+                .nickname(member.getNickname())
+                .collectionId(collection.getId())
+                .title(collection.getTitle())
                 .build();
     }
 

--- a/src/main/java/link/sendwish/backend/service/CollectionService.java
+++ b/src/main/java/link/sendwish/backend/service/CollectionService.java
@@ -36,7 +36,7 @@ public class CollectionService {
                 .memberCollections(new ArrayList<>())
                 .build();
 
-        Member member = memberRepository.findBynickname(dto.getNickname()).orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findByNickname(dto.getNickname()).orElseThrow(MemberNotFoundException::new);
         MemberCollection memberCollection = MemberCollection.builder()
                 .member(member)
                 .collection(collection)

--- a/src/main/java/link/sendwish/backend/service/CollectionService.java
+++ b/src/main/java/link/sendwish/backend/service/CollectionService.java
@@ -64,6 +64,7 @@ public class CollectionService {
                 .findAllByMember(member)
                 .orElseThrow(MemberCollectionNotFoundException::new)
                 .stream()
+                .filter(collection -> collection.getCollection().getReference() == 1)
                 .map(target -> CollectionResponseDto
                         .builder()
                         .title(target.getCollection().getTitle())

--- a/src/main/java/link/sendwish/backend/service/CustomUserDetailService.java
+++ b/src/main/java/link/sendwish/backend/service/CustomUserDetailService.java
@@ -18,7 +18,7 @@ public class CustomUserDetailService implements UserDetailsService {
 
     @Override
     public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
-        return memberRepository.findBynickname(username)
+        return memberRepository.findByNickname(username)
                 .orElseThrow(MemberNotFoundException::new);
     }
 

--- a/src/main/java/link/sendwish/backend/service/MemberService.java
+++ b/src/main/java/link/sendwish/backend/service/MemberService.java
@@ -5,6 +5,7 @@ import link.sendwish.backend.auth.TokenInfo;
 import link.sendwish.backend.common.exception.MemberExisitingIDException;
 import link.sendwish.backend.common.exception.MemberNotFoundException;
 import link.sendwish.backend.common.exception.PasswordNotSameException;
+import link.sendwish.backend.dtos.MemberFriendAddRequestDto;
 import link.sendwish.backend.dtos.MemberRequestDto;
 import link.sendwish.backend.entity.Member;
 import link.sendwish.backend.repository.MemberRepository;
@@ -44,6 +45,7 @@ public class MemberService {
                 .password(encode)
                 .roles(List.of("USER"))
                 .memberCollections(new ArrayList<>())
+                .friends(new ArrayList<>())
                 .build();
         Member savedMember = memberRepository.save(member);
         log.info("새로운 회원가입 [ID] : {}, [PW] : {}", savedMember.getNickname(), savedMember.getPassword());
@@ -75,5 +77,18 @@ public class MemberService {
         }
         return true;
     }
+
+    @Transactional
+    public Member addFriendToMe(MemberFriendAddRequestDto dto){
+        Long myId = dto.getMemberId();
+        Long friendId = dto.getAddMemberId();
+
+        Member myMember = memberRepository.findById(myId).orElseThrow(MemberNotFoundException::new);
+        Member friendMember = memberRepository.findById(friendId).orElseThrow(MemberNotFoundException::new);
+
+        myMember.addFriendInList(friendMember);
+        return friendMember;
+    }
+
 }
 

--- a/src/main/java/link/sendwish/backend/service/MemberService.java
+++ b/src/main/java/link/sendwish/backend/service/MemberService.java
@@ -2,10 +2,9 @@ package link.sendwish.backend.service;
 
 import link.sendwish.backend.auth.JwtTokenProvider;
 import link.sendwish.backend.auth.TokenInfo;
-import link.sendwish.backend.common.exception.MemberExisitingIDException;
-import link.sendwish.backend.common.exception.MemberNotFoundException;
-import link.sendwish.backend.common.exception.PasswordNotSameException;
+import link.sendwish.backend.common.exception.*;
 import link.sendwish.backend.dtos.MemberFriendAddRequestDto;
+import link.sendwish.backend.dtos.MemberFriendAddResponseDto;
 import link.sendwish.backend.dtos.MemberRequestDto;
 import link.sendwish.backend.entity.Member;
 import link.sendwish.backend.repository.MemberRepository;
@@ -55,7 +54,7 @@ public class MemberService {
     @Transactional
     public TokenInfo login(String nickname, String password) {
         // 멤버 아이디가 있는지, 패스워드가 제대로 되었는지
-        Member member = memberRepository.findBynickname(nickname).orElseThrow(MemberNotFoundException::new);
+        Member member = memberRepository.findByNickname(nickname).orElseThrow(MemberNotFoundException::new);
         if (passwordEncoder.matches(password, member.getPassword())) {
             UsernamePasswordAuthenticationToken authenticationToken = new UsernamePasswordAuthenticationToken(nickname, password);
             Authentication authentication = authenticationManagerBuilder.getObject().authenticate(authenticationToken);
@@ -65,29 +64,39 @@ public class MemberService {
     }
 
     public Member findMember(String nickname) {
-        return memberRepository.findBynickname(nickname).orElseThrow(MemberNotFoundException::new);
+        return memberRepository.findByNickname(nickname).orElseThrow(MemberNotFoundException::new);
     }
 
     /**
      * 아이디가 존재하는지 확인
      */
     public boolean checkExistingID(String nickname ){
-        if (!memberRepository.findBynickname(nickname).isEmpty()) {
+        if (!memberRepository.findByNickname(nickname).isEmpty()) {
             return false;
         }
         return true;
     }
 
     @Transactional
-    public Member addFriendToMe(MemberFriendAddRequestDto dto){
+    public MemberFriendAddResponseDto addFriendToMe(MemberFriendAddRequestDto dto){
         Long myId = dto.getMemberId();
         Long friendId = dto.getAddMemberId();
 
         Member myMember = memberRepository.findById(myId).orElseThrow(MemberNotFoundException::new);
         Member friendMember = memberRepository.findById(friendId).orElseThrow(MemberNotFoundException::new);
 
+        if (myMember.getFriends().contains(friendMember)){
+            throw new MemberFriendExistingException();
+        }
+
         myMember.addFriendInList(friendMember);
-        return friendMember;
+
+        log.info("나의 닉네임 : {}, 친구 닉네임 : {}", myMember.getNickname(), friendMember.getNickname());
+
+        return MemberFriendAddResponseDto.builder()
+                .nickname(myMember.getNickname())
+                .friendNickname(friendMember.getNickname())
+                .build();
     }
 
 }

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -19,6 +19,6 @@ spring:
         show_sql: true
         dialect: org.hibernate.dialect.H2Dialect
     hibernate:
-      ddl-auto: create
+      ddl-auto: update
 
 


### PR DESCRIPTION
### 작업 개요
#### 1. addFriend
- 친구 추가 기능 추가 (Member 객체 업데이트, 서비스 및 컨트롤러에 관련 메서드 추가)
- 에러메시지 순서 정리 (chore)


#### 2. findCollectionByMember
- 멤버가 생성한 모든 컬렉션 조회시 findCollectionByMember 메서드 수정 (reference == 1로 조건 추가, 아닐시 공유폴더)
- @rigyeonghong repo 참고하여 reference 일관성 유지하여 작성


#### 3. deleteCollection
- 멤버가 collection 삭제시 
- reference가 1일 경우 컬렉션 삭제
- reference가 1 초과일 경우 reference 1 감소 및 관련 메서드에서만 제거


#### 4. ddl-auto
- ddl-auto = create -> update로 수정

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화