### PR TITLE
feat: db에 저장된 아이템 url parsing 요청시 db값 반환 및 reference 업데이트, itemResponseDto에 itemId 추가

### DIFF
--- a/src/main/java/link/sendwish/backend/controller/ItemController.java
+++ b/src/main/java/link/sendwish/backend/controller/ItemController.java
@@ -62,6 +62,11 @@ public class ItemController {
             if(dto.getUrl() == null){
                 throw new DtoNullException();
             }
+            Item find = itemService.findItem(dto.getUrl());
+            if(find != null){
+                return ResponseEntity.ok().body(find.getId());
+            }
+
             /*
             * Python Server 호출, DB에 Item 등록
             * */

--- a/src/main/java/link/sendwish/backend/controller/ItemController.java
+++ b/src/main/java/link/sendwish/backend/controller/ItemController.java
@@ -64,6 +64,7 @@ public class ItemController {
             }
             Item find = itemService.findItem(dto.getUrl());
             if(find != null){
+                itemService.checkMemberReferenceByItem(find, dto.getNickname());
                 return ResponseEntity.ok().body(find.getId());
             }
 

--- a/src/main/java/link/sendwish/backend/dtos/ItemResponseDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/ItemResponseDto.java
@@ -10,6 +10,7 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 @AllArgsConstructor
 public class ItemResponseDto {
+    private Long itemId;
     private int price;
     private String name;
     private String imgUrl;

--- a/src/main/java/link/sendwish/backend/repository/ItemRepository.java
+++ b/src/main/java/link/sendwish/backend/repository/ItemRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface ItemRepository extends JpaRepository<Item, Long> {
     Optional<Item> findById(Long itemId);
+    Optional<Item> findByOriginUrl(String url);
 }

--- a/src/main/java/link/sendwish/backend/repository/MemberItemRepository.java
+++ b/src/main/java/link/sendwish/backend/repository/MemberItemRepository.java
@@ -1,5 +1,6 @@
 package link.sendwish.backend.repository;
 
+import link.sendwish.backend.entity.Item;
 import link.sendwish.backend.entity.Member;
 import link.sendwish.backend.entity.MemberItem;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -9,4 +10,5 @@ import java.util.Optional;
 
 public interface MemberItemRepository extends JpaRepository<MemberItem, Long> {
     Optional<List<MemberItem>> findAllByMember(Member member);
+    Optional<List<MemberItem>> findAllByItem(Item item);
 }

--- a/src/main/java/link/sendwish/backend/service/CollectionService.java
+++ b/src/main/java/link/sendwish/backend/service/CollectionService.java
@@ -90,6 +90,8 @@ public class CollectionService {
                 .nickname(nickname)
                 .dtos(items.stream().map(
                         target -> ItemResponseDto.builder()
+                                .originUrl(target.getOriginUrl())
+                                .itemId(target.getId())
                                 .price(target.getPrice())
                                 .name(target.getName())
                                 .imgUrl(target.getImgUrl())
@@ -199,6 +201,8 @@ public class CollectionService {
         log.info("컬렉션 아이템 복사 [복사된 컬랙션 제목] : {}", findByCache.getTitle());
         return items.stream().map(
                         item -> ItemResponseDto.builder()
+                                .itemId(item.getId())
+                                .originUrl(item.getOriginUrl())
                                 .price(item.getPrice())
                                 .name(item.getName())
                                 .imgUrl(item.getImgUrl())

--- a/src/main/java/link/sendwish/backend/service/ItemService.java
+++ b/src/main/java/link/sendwish/backend/service/ItemService.java
@@ -14,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 import link.sendwish.backend.common.exception.ItemNotFoundException;
 
 import java.util.List;
+import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)
@@ -104,6 +105,11 @@ public class ItemService {
 
         log.info("맴버 아이템 일괄 조회 [ID] : {}, [아이템 갯수] : {}", member.getNickname(), dtos.size());
         return dtos;
+    }
+
+    public Item findItem(String url) {
+        Optional<Item> findByUrl = itemRepository.findByOriginUrl(url);
+        return findByUrl.orElse(null);
     }
 
 }

--- a/src/main/java/link/sendwish/backend/service/ItemService.java
+++ b/src/main/java/link/sendwish/backend/service/ItemService.java
@@ -57,6 +57,7 @@ public class ItemService {
                 .name(item.getName())
                 .price(item.getPrice())
                 .originUrl(item.getOriginUrl())
+                .itemId(item.getId())
                 .build();
     }
 
@@ -100,6 +101,7 @@ public class ItemService {
                         .originUrl(target.getItem().getOriginUrl())
                         .imgUrl(target.getItem().getImgUrl())
                         .price(target.getItem().getPrice())
+                        .itemId(target.getItem().getId())
                         .build()
                 ).toList();
 

--- a/src/main/java/link/sendwish/backend/service/ItemService.java
+++ b/src/main/java/link/sendwish/backend/service/ItemService.java
@@ -114,4 +114,23 @@ public class ItemService {
         return findByUrl.orElse(null);
     }
 
+    @Transactional
+    public Long checkMemberReferenceByItem(Item item, String nickname) {
+        Member member = memberService.findMember(nickname);
+        long find = memberItemRepository
+                .findAllByItem(item)
+                .get()
+                .stream()
+                .filter(target -> target
+                        .getMember()
+                        .getId()
+                        .equals(member.getId()))
+                        .count();
+        if(find == 0){
+            item.addReference();
+        }
+        log.info("이미 존재하는 아이템 [ID] : {}, [참조하는 맴버 수] : {}", item.getNickname(), item.getReference());
+        return item.getId();
+    }
+
 }

--- a/src/main/java/link/sendwish/backend/service/ItemService.java
+++ b/src/main/java/link/sendwish/backend/service/ItemService.java
@@ -69,10 +69,10 @@ public class ItemService {
 
         if(item.getReference() == 1){
             itemRepository.delete(item);
-            log.info("아이템 삭제 [ID] : {}, [남은 참조 갯수] : {}", itemId, 0);
+            log.info("아이템 삭제 [ID] : {}, [참조 맴버 수] : {}", itemId, 0);
         }else {
             item.subtractReference();
-            log.info("아이템 삭제 [ID] : {}, [남은 참조 갯수] : {}", itemId, item.getReference());
+            log.info("아이템 삭제 [ID] : {}, [참조 맴버 수] : {}", itemId, item.getReference());
 
             Member member = memberService.findMember(nickname);
             List<CollectionResponseDto> memberCollection = collectionService.findCollectionsByMember(member);


### PR DESCRIPTION
### 작업 개요
- 아이템 url parsing 요청시, 해당 정보가 db에 존재한다면 그대로 반환
- db에 존재하는 아이템을 저장한 맴버가 요청한 맴버가 아니라면 item reference 수 증가

- ItemResponseDto에 itemId 추가 

구현 예시)
<img width="1209" alt="image" src="https://user-images.githubusercontent.com/77164776/211359997-ca91f356-e20b-463e-a3d6-c2faa2ab6324.png">



### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화