### PR TITLE
update:GET 아이템 최신순 기존 방식 변경 

### DIFF
--- a/src/main/java/link/sendwish/backend/repository/MemberItemRepository.java
+++ b/src/main/java/link/sendwish/backend/repository/MemberItemRepository.java
@@ -9,6 +9,6 @@ import java.util.List;
 import java.util.Optional;
 
 public interface MemberItemRepository extends JpaRepository<MemberItem, Long> {
-    Optional<List<MemberItem>> findAllByMember(Member member);
+    Optional<List<MemberItem>> findAllByMemberOrderByIdDesc(Member member);
     Optional<List<MemberItem>> findAllByItem(Item item);
 }

--- a/src/main/java/link/sendwish/backend/service/ItemService.java
+++ b/src/main/java/link/sendwish/backend/service/ItemService.java
@@ -92,27 +92,22 @@ public class ItemService {
     }
 
     public List<ItemResponseDto> findItemByMember(Member member) {
-        Stack<MemberItem> stack = new Stack<>();
-        List<ItemResponseDto> dtos = new ArrayList<>();
-        if (memberItemRepository.findAllByMember(member).isEmpty()) {
+        List<ItemResponseDto> dtos;
+        if (memberItemRepository.findAllByMemberOrderByIdDesc(member).isEmpty()) {
+            dtos = new ArrayList<>();
             log.info("맴버 아이템 일괄 조회 [ID] : {},해당 멤버는 가진 아이템이 없습니다.", member.getNickname());
             return dtos;
         }
-        List<MemberItem> memberItems = memberItemRepository.findAllByMember(member).get();
-        for (MemberItem memberItem : memberItems) {
-            stack.push(memberItem);
-        }
-        while (!stack.isEmpty()) {
-            MemberItem memberItem = stack.pop();
-            Item item = memberItem.getItem();
-            dtos.add(ItemResponseDto.builder()
-                    .itemId(item.getId())
-                    .name(item.getName())
-                    .price(item.getPrice())
-                    .imgUrl(item.getImgUrl())
-                    .originUrl(item.getOriginUrl())
-                    .build());
-        }
+        dtos = memberItemRepository.findAllByMemberOrderByIdDesc(member)
+                .get()
+                .stream().map(target -> ItemResponseDto.builder()
+                        .originUrl(target.getItem().getOriginUrl())
+                        .name(target.getItem().getName())
+                        .price(target.getItem().getPrice())
+                        .imgUrl(target.getItem().getImgUrl())
+                        .itemId(target.getItem().getId())
+                        .build()
+                ).collect(Collectors.toList());
         log.info("맴버 아이템 일괄 조회 [ID] : {}, [아이템 갯수] : {}", member.getNickname(), dtos.size());
         return dtos;
     }


### PR DESCRIPTION
### 작업 개요
- 기존의 stack 자료구조를 메모리에서 사용하는 구조에서 MemberItem 테이블의 Id(pk)를 사용해서 desc으로 JPA 단에서 정렬 되도록 변경

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화