### PR TITLE
fix:sharedCollection create, target collection 없을시 빈리스트 return

### DIFF
--- a/src/main/java/link/sendwish/backend/controller/CollectionController.java
+++ b/src/main/java/link/sendwish/backend/controller/CollectionController.java
@@ -102,7 +102,7 @@ public class CollectionController {
     @PostMapping("/collection/shared")
     public ResponseEntity<?> sharedCollection(@RequestBody CollectionSharedCreateRequestDto dto) {
         try {
-            if (dto.getTitle() == null || dto.getTargetCollectionId() == null) {
+            if (dto.getTitle() == null) {
                 throw new RuntimeException("잘못된 DTO 요청입니다.");
             }
 
@@ -139,6 +139,8 @@ public class CollectionController {
                         (dto.getTargetCollectionId(), savedCollection.getNickname());// 1차 캐시
                 List<ItemResponseDto> copyItemToCollection = collectionService.copyItemToCollection(copyTarget.getCollectionId(),find.getCollectionId());
                 responseDto.setDtos(copyItemToCollection);
+            } else {
+                responseDto.setDtos(Collections.emptyList());
             }
             return ResponseEntity.ok().body(responseDto);
             }catch (Exception e) {


### PR DESCRIPTION
### 작업 개요
- shared collection에 타겟 콜렉션 없을시 dto 에러 삭제
- target collection 없을시 빈리스트 리턴

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화