### PR TITLE
feat: 해당 사용자의 아이템 카테고리 선호도 구현

### DIFF
--- a/src/main/java/link/sendwish/backend/dtos/item/ItemCategoryResponseDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/item/ItemCategoryResponseDto.java
@@ -5,15 +5,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ItemResponseDto {
-    private Long itemId;
-    private int price;
-    private String name;
-    private String imgUrl;
-    private String originUrl;
+public class ItemCategoryResponseDto {
     private String category;
+    private Integer percentage;
+    private List<ItemResponseDto> itemDtos;
 }

--- a/src/main/java/link/sendwish/backend/entity/Item.java
+++ b/src/main/java/link/sendwish/backend/entity/Item.java
@@ -31,6 +31,9 @@ public class Item {
     @Builder.Default
     private int reference = 1;
 
+    @Column(nullable = false)
+    private String category;
+
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
     private List<CollectionItem> collectionItems = new ArrayList<>();
 


### PR DESCRIPTION
### 작업 개요
- 맴버가 담은 아이템 카테고리별 순위 5위까지 반환
- 총 8가지 카테고리로 분류됨 (디지털/테크, 리빙, 모자, 가방/지갑, 신발, 뷰티/악세사리, 옷, ETC)

- 아이템에 category 필드 추가

예시)
<img width="1338" alt="스크린샷 2023-01-22 오후 7 27 46" src="https://user-images.githubusercontent.com/77164776/213911353-619b2d5b-f2ad-4386-b90e-8921d9f94c95.png">

- 추후) 속도 개선 위해 스크래핑 api와 카테고리 분류 api 분리 예정

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화