### PR TITLE
feat: item analysis and storage asynchronous processing using webclient

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -59,6 +59,10 @@ dependencies {
 	//redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	//WebClient
+	implementation 'org.springframework.boot:spring-boot-starter-webflux:2.5.6'
+	implementation 'org.projectreactor:reactor-spring:1.0.1.RELEASE'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/link/sendwish/backend/dtos/item/ItemCategoryRequestDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/item/ItemCategoryRequestDto.java
@@ -9,7 +9,6 @@ import lombok.NoArgsConstructor;
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ItemCategoryResponseDto {
+public class ItemCategoryRequestDto {
     private String imgUrl;
-    private String category;
 }

--- a/src/main/java/link/sendwish/backend/dtos/item/ItemPreferenceResponseDto.java
+++ b/src/main/java/link/sendwish/backend/dtos/item/ItemPreferenceResponseDto.java
@@ -5,11 +5,14 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.List;
+
 @Data
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
-public class ItemCategoryResponseDto {
-    private String imgUrl;
+public class ItemPreferenceResponseDto {
     private String category;
+    private Integer percentage;
+    private List<ItemResponseDto> itemDtos;
 }

--- a/src/main/java/link/sendwish/backend/entity/Item.java
+++ b/src/main/java/link/sendwish/backend/entity/Item.java
@@ -31,7 +31,6 @@ public class Item {
     @Builder.Default
     private int reference = 1;
 
-    @Column(nullable = false)
     private String category;
 
     @OneToMany(mappedBy = "item", cascade = CascadeType.ALL)
@@ -62,5 +61,9 @@ public class Item {
 
     public void subtractReference() {
         this.reference -= 1;
+    }
+
+    public void updateCategory(String category) {
+        this.category = category;
     }
 }


### PR DESCRIPTION
### 작업 개요
- WebFlux의 webclient를 활용해 비동기적 아이템 분석 및 저장 구현
- 사용자가 장바구니에 담은 아이템 분석 및 저장 기능 흐름 요약
1) spring web server로 url 받음
2) flask scrapping server에 파싱 요청 
3) 반환 받은 데이터 저장 후 client에 저장된 아이템id 반환
4) 비동기적으로 해당 아이템 분석 ai server에 요청
5) 반환받은 카테고리 분류 결과를 아이템id에 update

### 작업 분류
- [ ] 버그 수정
- [x] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화