### PR TITLE
fix: 삭제하는 아이템이 공유 컬랙션내 있을 시 해당 아이템 메세지 삭제 & 투표방 퇴장시 socket 연결 해제 및 데이터 삭제

### DIFF
--- a/src/main/java/link/sendwish/backend/controller/MessageController.java
+++ b/src/main/java/link/sendwish/backend/controller/MessageController.java
@@ -42,12 +42,7 @@ public class MessageController {
     @MessageMapping("/live/enter")
     public void sendLiveMessage(LiveEnterRequestDto dto){
         log.info("{} 님이 통화에 참여합니다.", dto.getNickname());
-        if (webRtcSessions.containsKey(dto.getRoomId())) {
-            webRtcSessions.get(dto.getRoomId()).add(dto.getNickname());
-        } else {
-            webRtcSessions.put(dto.getRoomId(), List.of(dto.getNickname()));
-        }
-        this.template.convertAndSend("/sub/live/enter/" + dto.getRoomId(), webRtcSessions.get(dto.getRoomId()));      
+        this.template.convertAndSend("/sub/live/enter/" + dto.getRoomId(), dto.getNickname());
     }
 
     @MessageMapping("/vote/enter")
@@ -62,5 +57,12 @@ public class MessageController {
         ChatVoteResponseDto like = voteService.like(dto);
         log.info("{} 님이 투표를 했습니다.", dto.getNickname());
         this.template.convertAndSend("/sub/vote/" + dto.getRoomId(), like);
+    }
+
+    @MessageMapping("/vote/exit")
+    public void sendVoteExit(ChatVoteEnterRequestDto dto){
+        ChatVoteEnterResponseDto exit = voteService.exitVote(dto);
+        log.info("{} 님이 투표방에 나갔습니다.", dto.getNickname());
+        this.template.convertAndSend("/sub/vote/exit/" + dto.getRoomId(), exit);
     }
 }

--- a/src/main/java/link/sendwish/backend/repository/ChatMessageRepository.java
+++ b/src/main/java/link/sendwish/backend/repository/ChatMessageRepository.java
@@ -10,4 +10,5 @@ import java.util.Optional;
 public interface ChatMessageRepository extends JpaRepository<ChatMessage, Long> {
     Optional<List<ChatMessage>> findAllByChatRoom(ChatRoom room);
     Optional<ChatMessage> findTopByChatRoomOrderByIdDesc(ChatRoom room);
+    Optional<List<ChatMessage>> findByItemIdAndSender(Long itemId, String nickname);
 }

--- a/src/main/java/link/sendwish/backend/service/ChatService.java
+++ b/src/main/java/link/sendwish/backend/service/ChatService.java
@@ -217,4 +217,13 @@ public class ChatService {
         return dtos;
     }
 
+    public void deleteChatMessageByItemId(Long itemId, String nickname){
+
+        List<ChatMessage> messages = chatMessageRepository.findByItemIdAndSender(itemId, nickname).orElse(null);
+        if (messages != null) {
+            chatMessageRepository.deleteAll(messages);
+            log.info("채팅방 아이템 메세지 삭제 [ID] : {}, 삭제하는 맴버 [ID] : {}", itemId, nickname);
+        }
+    }
+
 }

--- a/src/main/java/link/sendwish/backend/service/ItemService.java
+++ b/src/main/java/link/sendwish/backend/service/ItemService.java
@@ -117,9 +117,7 @@ public class ItemService {
             }else{
                 item.subtractReference();
                 log.info("아이템 삭제 [ID] : {}, [참조 맴버 수] : {}", itemId, item.getReference());
-                /*
-                 * Cascade Option 적용 X
-                 * */
+
                 MemberItem memberItem = memberItemRepository.findByMemberAndItem(member, item)
                         .orElseThrow(RuntimeException::new);
                 memberItemRepository.delete(memberItem);
@@ -129,6 +127,7 @@ public class ItemService {
                     log.info("컬렉션 아이템 삭제 [ID] : {}", collectionItem.getId());
                 });
             }
+            chatService.deleteChatMessageByItemId(itemId, nickname);
         }
 
         return ItemDeleteResponseDto.builder()
@@ -141,7 +140,7 @@ public class ItemService {
         List<ItemResponseDto> dtos;
         if (memberItemRepository.findAllByMemberOrderByIdDesc(member).isEmpty()) {
             dtos = new ArrayList<>();
-            log.info("맴버 아이템 일괄 조회 [ID] : {},해당 멤버는 가진 아이템이 없습니다.", member.getNickname());
+            log.info("맴버 아이템 일괄 조회 [ID] : {}, 해당 멤버는 가진 아이템이 없습니다.", member.getNickname());
             return dtos;
         }
         dtos = memberItemRepository.findAllByMemberOrderByIdDesc(member)
@@ -240,7 +239,7 @@ public class ItemService {
                 .imgUrl(imgUrl)
                 .build();
 
-        String uri = "http://3.36.131.201:5000/category";
+        String uri = "http://3.354.17.29:5001/category";
         Flux<ItemCategoryResponseDto> stringFlux = WebClient.create()
                 .post()
                 .uri(uri)


### PR DESCRIPTION
### 작업 개요
- 삭제하는 아이템이 공유 컬랙션내 있을 시 해당 아이템 메세지 삭제 
- 삭제하는 아이템이 공유 컬랙션에서는 삭제되나 해당 아이템 추가 알림 메세지에는 삭제되지 않아, 
  채팅방 로딩시 해당 아이템 참조로 인한 오류 발생하여 추가 구현

- 투표방 퇴장시 socket 연결 해제 및 데이터 삭제
- 투표방 퇴장시 socket 연결 해제 알림을 프론트로부터 받지 않아 퇴장했음에도 남아있는 문제 발견하여, 
socket 연결 해제시 알림 받고 데이터 삭제하도록 수정

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화