### PR TITLE
fix: 스크래핑 서버, 카테고리 분석 서버 uri yml로 분리 후 함수 주입, queue 삭제

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@
 # https
 *.p12
 
+application-auth.yml
 application-dev.yml
 application-aws.yml
 

--- a/src/main/java/link/sendwish/backend/controller/MessageController.java
+++ b/src/main/java/link/sendwish/backend/controller/MessageController.java
@@ -42,7 +42,7 @@ public class MessageController {
     @MessageMapping("/live/enter")
     public void sendLiveMessage(LiveEnterRequestDto dto){
         log.info("{} 님이 통화에 참여합니다.", dto.getNickname());
-        this.template.convertAndSend("/sub/live/enter/" + dto.getRoomId(), dto.getNickname());
+        this.template.convertAndSend("/sub/live/enter/" + dto.getRoomId(), dto);
     }
 
     @MessageMapping("/vote/enter")

--- a/src/main/java/link/sendwish/backend/service/ItemService.java
+++ b/src/main/java/link/sendwish/backend/service/ItemService.java
@@ -234,12 +234,11 @@ public class ItemService {
         return dtos;
     }
 
-    public Flux<ItemCategoryResponseDto> categorization(String imgUrl, Item item) {
+    public Flux<ItemCategoryResponseDto> categorization(String imgUrl, Item item, String uri) {
         ItemCategoryRequestDto img = ItemCategoryRequestDto.builder()
                 .imgUrl(imgUrl)
                 .build();
 
-        String uri = "http://3.354.17.29:5001/category";
         Flux<ItemCategoryResponseDto> stringFlux = WebClient.create()
                 .post()
                 .uri(uri)
@@ -251,6 +250,7 @@ public class ItemService {
             item.updateCategory(responseDto.getCategory());
             itemRepository.save(item);
         });
+        log.debug("Flux async");
         return stringFlux;
     }
 }

--- a/src/main/java/link/sendwish/backend/service/VoteService.java
+++ b/src/main/java/link/sendwish/backend/service/VoteService.java
@@ -63,6 +63,7 @@ public class VoteService {
         String key = dto.getRoomId() + ":" + dto.getItemId();
         String value = dto.getNickname();
 
+        log.info("맴버 [ID] : {} 가, [좋아요] : {} 를 눌렀습니다.", dto.getNickname(), dto.getIsLike());
         String find = like.get(key);
         if (dto.getIsLike()) { // 좋아요 누른 경우
             if (find == null) {

--- a/src/main/resources/application-auth.yml
+++ b/src/main/resources/application-auth.yml
@@ -5,3 +5,8 @@ app:
   auth:
     accessTokenExpiry: 1800000
     refreshTokenExpiry: 1209600000
+
+server:
+  url:
+    scrap: http://13.209.229.237:5000/webscrap
+    category: http://3.35.174.29:5001/category

--- a/src/main/resources/application-local.yml
+++ b/src/main/resources/application-local.yml
@@ -21,4 +21,7 @@ spring:
     hibernate:
       ddl-auto: create
 
+  redis:
+    host: localhost
+    port: 6379
 


### PR DESCRIPTION
### 작업 개요
- 스크래핑 서버, 카테고리 분석 서버 uri yml로 분리 후 함수 주입 (application-auth.yml 공유 필요)
- queue 삭제
- live 통화 참여시 반환값 수정

### 작업 분류
- [x] 버그 수정
- [ ] 신규 기능
- [ ] 프로젝트 구조 변경
- [ ] 테스트 코드 작성
- [ ]  문서화